### PR TITLE
Ensure incoming type is correct type

### DIFF
--- a/cvnp/cvnp.h
+++ b/cvnp/cvnp.h
@@ -104,6 +104,9 @@ namespace pybind11
              */
             bool load(handle src, bool)
             {
+                if (!isinstance<array>(src)) {
+                    return false;
+                }
                 auto a = reinterpret_borrow<array>(src);
                 auto new_mat = cv::Mat(cvnp::nparray_to_mat(a));
                 value.Value = new_mat;
@@ -143,6 +146,9 @@ namespace pybind11
              */
             bool load(handle src, bool)
             {
+                if (!isinstance<array>(src)) {
+                    return false;
+                }
                 auto a = reinterpret_borrow<array>(src);
                 auto new_mat = cvnp::nparray_to_mat(a);
                 value = new_mat;
@@ -182,6 +188,10 @@ namespace pybind11
             // Conversion part 1 (Python->C++)
             bool load(handle src, bool)
             {
+                if (!isinstance<array>(src)) {
+                    return false;
+                }
+
                 auto a = reinterpret_borrow<array>(src);
                 cvnp::nparray_to_matx<_Tp, _rows, _cols>(a, value.Value);
                 return true;
@@ -213,6 +223,10 @@ namespace pybind11
             // Conversion part 1 (Python->C++)
             bool load(handle src, bool)
             {
+                if (!isinstance<array>(src)) {
+                    return false;
+                }
+
                 auto a = reinterpret_borrow<array>(src);
                 cvnp::nparray_to_matx<_Tp, _rows, _cols>(a, value);
                 return true;
@@ -244,6 +258,10 @@ namespace pybind11
             // Conversion part 1 (Python->C++, i.e tuple -> Size)
             bool load(handle src, bool)
             {
+                if (!isinstance<pybind11::tuple>(src)) {
+                    return false;
+                }
+
                 auto tuple = pybind11::reinterpret_borrow<pybind11::tuple>(src);
                 if (tuple.size() != 2)
                     throw std::invalid_argument("Size should be in a tuple of size 2");
@@ -281,6 +299,10 @@ namespace pybind11
             // Conversion part 1 (Python->C++)
             bool load(handle src, bool)
             {
+                if (!isinstance<pybind11::tuple>(src)) {
+                    return false;
+                }
+
                 auto tuple = pybind11::reinterpret_borrow<pybind11::tuple>(src);
                 if (tuple.size() != 2)
                     throw std::invalid_argument("Point should be in a tuple of size 2");
@@ -318,6 +340,10 @@ namespace pybind11
             // Conversion part 1 (Python->C++)
             bool load(handle src, bool)
             {
+                if (!isinstance<pybind11::tuple>(src)) {
+                    return false;
+                }
+
                 auto tuple = pybind11::reinterpret_borrow<pybind11::tuple>(src);
                 if (tuple.size() != 3)
                     throw std::invalid_argument("Point3 should be in a tuple of size 3");


### PR DESCRIPTION
- If the type is wrong, segfaults can happen

By the way, just found this, it seems really useful! I had been using my own extract of OpenCV's ndarray converted, but this seems much better.