### PR TITLE
Allow empty images

### DIFF
--- a/tests/test_cvnp.py
+++ b/tests/test_cvnp.py
@@ -411,11 +411,20 @@ def test_short_lived_mat():
     assert (m[0, 0] == (12, 34, 56, 78)).all()
 
 
+def test_empty_mat():
+    m = np.zeros(shape=(0,0,3))
+    m2 = cvnp_roundtrip(m)
+    assert (m == m2).all()
+    m3 = cvnp_roundtrip_shared(m)
+    assert (m == m3).all()
+
+
 def main():
     # Todo: find a way to call pytest for this file
     test_mat_shared()
     test_matx_shared()
     test_cvnp_round_trip()
+    test_empty_mat()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- They aren't continuous, but there's no data to share anyways so that's fine

Fixes the issue I was running into in #6 so we can close it... though I do think there's a way to convince numpy and opencv to agree on weird strides, but I don't really care enough at the present moment.