### PR TITLE
Do not enforce Python_EXECUTABLE definition or execute_process if PROJECT_IS_TOP_LEVEL is FALSE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,24 +3,23 @@ project(cvnp LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 14)
 
-if(NOT Python_EXECUTABLE)
-    message(FATAL_ERROR "
-    Please set the Python_EXECUTABLE variable to a python interpreter
-    where you installed numpy and opencv. For example:
-
-        cmake .. -DPython_EXECUTABLE=/venv/bin/python
-")
-endif()
-
-# Find site-packages directory (needed for tests)
-execute_process(
-    COMMAND ${Python_EXECUTABLE} -c "import site; print(site.getsitepackages()[0])"
-    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_DIRECTORY
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-
 if (PROJECT_IS_TOP_LEVEL)
+    if(NOT Python_EXECUTABLE)
+        message(FATAL_ERROR "
+        Please set the Python_EXECUTABLE variable to a python interpreter
+        where you installed numpy and opencv. For example:
+
+            cmake .. -DPython_EXECUTABLE=/venv/bin/python
+    ")
+    endif()
+
+    # Find site-packages directory (needed for tests)
+    execute_process(
+        COMMAND ${Python_EXECUTABLE} -c "import site; print(site.getsitepackages()[0])"
+        OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_DIRECTORY
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
     # Add address sanitizer
     option(CVNP_ENABLE_ASAN "Enable Address Sanitizer" OFF)
     if (CVNP_ENABLE_ASAN)


### PR DESCRIPTION
Hello @pthom, thanks a lot for the work on cvnp.

While updating a project to the latest cvnp, I experience a failure as `Python_EXECUTABLE` is not defined in our project (as we use `find_package(Python3)` and not `find_package(Python)`).

However, it seems that `Python_EXECUTABLE` is not used if PROJECT_IS_TOP_LEVEL is OFF, so perhaps it could make sense to move the check for  `Python_EXECUTABLE` being defined inside the `if(PROJECT_IS_TOP_LEVEL)` ? This is also beneficial in cross-compilation scenarios, where `execute_process` may fail.